### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
     "pretest": "npm run lint",
     "test": "npm run test:coverage",
-    "prepare": "npm run build",
     "release": "standard-version",
     "prepublishOnly": "pnpm run build",
     "lint:write": "rslint --fix"


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update**
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Build packages explicitly in the release workflow before `pnpm stage publish` and remove the duplicate `prepare` build command.

### Breaking Changes

None.

### Additional Info

Validated workflow ordering and ran `git diff --check`.