### PR TITLE
chore: update peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x || ^2.0.0-0",
+    "@rspack/core": "0.x || 1.x || ^2.0.0",
     "webpack": "^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@rspack/core':
-        specifier: 0.x || 1.x || ^2.0.0-0
+        specifier: 0.x || 1.x || ^2.0.0
         version: 1.7.6
       loader-utils:
         specifier: ^2.0.0


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Update the `@rspack/core` peer dependency range from the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). This keeps the existing `0.x || 1.x` compatibility alternatives and avoids targeting prerelease 2.x builds.

### Breaking Changes

None.

### Additional Info

No runtime code changes.