### PR TITLE
chore: update pnpm release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,13 @@
 allowBuilds:
   puppeteer: false
+
+minimumReleaseAgeExclude:
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rslint/*'
+  - '@rspack/*'
+  - '@rspress/*'
+  - '@rstackjs/*'
+  - '@rstest/*'
+  - 'rsbuild-plugin-*'
+  - rstack


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update**
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

This PR updates `minimumReleaseAgeExclude` to exempt Rstack ecosystem packages from pnpm's minimum release age policy.

### Breaking Changes

None.

### Additional Info

Existing exclusions are preserved and the complete list is sorted alphabetically.